### PR TITLE
Update GenerateInsertStatements.java

### DIFF
--- a/javautil-jdbc/src/main/java/org/javautil/jdbc/dml/GenerateInsertStatements.java
+++ b/javautil-jdbc/src/main/java/org/javautil/jdbc/dml/GenerateInsertStatements.java
@@ -146,6 +146,7 @@ public class GenerateInsertStatements {
 						columnValues += "TO_DATE('" + dateFormat.format(d)
 								+ "', 'YYYY/MM/DD HH24:MI:SS')";
 					}
+					d=null;
 					break;
 
 				default:


### PR DESCRIPTION
d variable has to be made null sometimes to be updated in TIME and TIMESTAMP type. Without that it is assigned once and reused for each row and column.